### PR TITLE
Introduce Tests for API Spec

### DIFF
--- a/tests/aux.maude
+++ b/tests/aux.maude
@@ -1,0 +1,29 @@
+mod TEST-CONSTANTS is
+  pr APP-ID .
+  pr TA-INSTANCE-ID .
+  pr CONFIGURATION .
+
+  op testRa : -> Oid [ctor] .
+  op testTa : -> TaInstId [ctor] .
+
+  op TESTTA : -> AppId [ctor] .
+endm
+
+mod TEST-PROGRAM-DECL is
+  pr IMP-PROGRAM .
+
+  op sess : -> Var [ctor] .
+  op ret : -> Var [ctor] .
+
+  op res : -> Var [ctor] .
+  op srcKey : -> Var [ctor] .
+  op destKey : -> Var [ctor] .
+  op attr : -> Var [ctor] .
+
+  op main : -> FuncId [ctor] .
+endm
+
+mod TEST-AUX is
+  pr TEST-CONSTANTS .
+  pr TEST-PROGRAM-DECL .
+endm

--- a/tests/cases/aux.maude
+++ b/tests/cases/aux.maude
@@ -31,6 +31,8 @@ mod TEST-PROGRAM-DECL is
   op attr : -> Var [ctor] .
   op objDataFlag : -> Var [ctor] .
   op object : -> Var [ctor] .
+  op data : -> Var [ctor] .
+  op objectInfo : -> Var [ctor] .
 
   op main : -> FuncId [ctor] .
 endm

--- a/tests/cases/aux.maude
+++ b/tests/cases/aux.maude
@@ -34,6 +34,15 @@ mod TEST-PROGRAM-DECL is
   op data : -> Var [ctor] .
   op objectInfo : -> Var [ctor] .
 
+  op op : -> Var [ctor] .
+  op key : -> Var [ctor] .
+  op iv : -> Var [ctor] .
+  op srcData : -> Var [ctor] .
+  op destData : -> Var [ctor] .
+  op chunk : -> Var [ctor] .
+  op message : -> Var [ctor] .
+  op mac : -> Var [ctor] .
+
   op main : -> FuncId [ctor] .
 endm
 

--- a/tests/cases/aux.maude
+++ b/tests/cases/aux.maude
@@ -43,6 +43,8 @@ mod TEST-PROGRAM-DECL is
   op message : -> Var [ctor] .
   op mac : -> Var [ctor] .
 
+  op objEnumerator : -> Var [ctor] .
+
   op main : -> FuncId [ctor] .
 endm
 

--- a/tests/cases/aux.maude
+++ b/tests/cases/aux.maude
@@ -1,12 +1,22 @@
 mod TEST-CONSTANTS is
   pr APP-ID .
   pr TA-INSTANCE-ID .
+  pr TA-OBJECT-ID .
+  pr FILE-ID .
   pr CONFIGURATION .
 
   op testRa : -> Oid [ctor] .
+  op osId : -> Oid .
+
   op testTa : -> TaInstId [ctor] .
 
+  ops persistentObjId dataStreamId : -> TaObjectId .
+
+  op testFileId : -> FileId .
+  op newTestFileId : -> FileId .
+
   op TESTTA : -> AppId [ctor] .
+  
 endm
 
 mod TEST-PROGRAM-DECL is
@@ -19,6 +29,8 @@ mod TEST-PROGRAM-DECL is
   op srcKey : -> Var [ctor] .
   op destKey : -> Var [ctor] .
   op attr : -> Var [ctor] .
+  op objDataFlag : -> Var [ctor] .
+  op object : -> Var [ctor] .
 
   op main : -> FuncId [ctor] .
 endm

--- a/tests/cases/cryptographic.maude
+++ b/tests/cases/cryptographic.maude
@@ -1,0 +1,154 @@
+mod CRYPTOGRAPHIC-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  ops testCryptoGeneric testCryptoCipher testCryptoMAC testCryptoMisc : -> Program [ctor] .
+
+  op keyForCipherExists : -> Stmt [ctor] .
+  eq keyForCipherExists = 
+    AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits ; res, key) ;
+    InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+    PopulateTransientObject(key, attr  ; res) .
+
+  op keySetOperationForCipherExists : -> Stmt [ctor] .
+  eq keySetOperationForCipherExists = 
+    keyForCipherExists ;
+    AllocateOperation(# TEE-ALG-AES-CBC-NOPAD, # TEE-MODE-ENCRYPT, # 256 Bits  ; res, op) ;
+    SetOperationKey(op, key ; res) ;
+    FreeTransientObject(key ; key) . --- To analyze results better
+
+  op keyForMACExists : -> Stmt [ctor] .
+  eq keyForMACExists = 
+    AllocateTransientObject(# TEE-TYPE-HMAC-SHA256, # 256 Bits ; res, key) ;
+    InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+    PopulateTransientObject(key, attr  ; res) .
+
+  op keySetOperationForMACExists : -> Stmt [ctor] .
+  eq keySetOperationForMACExists = 
+    keyForMACExists ;
+    AllocateOperation(# TEE-ALG-HMAC-SHA256, # TEE-MODE-MAC, # 256 Bits  ; res, op) ;
+    SetOperationKey(op, key ; res) ;
+    FreeTransientObject(key ; key) . --- To analyze results better
+
+  eq testCryptoGeneric = 
+    main () 
+    {
+      var res ; var op ;
+      var attr ; var key ;
+      var iv ; iv := # noData ;
+
+      --- For TEE_AllocateOperation
+      --- Test Case 1 (For Symmetric Cipher)
+      --- AllocateOperation(# TEE-ALG-AES-CBC-NOPAD, # TEE-MODE-ENCRYPT, # 256 Bits  ; res, op) ;
+      --- return res
+
+      --- Test Case 2 (For MAC)
+      --- AllocateOperation(# TEE-ALG-HMAC-SHA256, # TEE-MODE-MAC, # 256 Bits  ; res, op) ;
+      --- return res
+
+      --- For TEE_SetOperationKey
+      --- Test Case 1
+      --- keyForCipherExists ;
+      --- AllocateOperation(# TEE-ALG-AES-CBC-NOPAD, # TEE-MODE-ENCRYPT, # 256 Bits  ; res, op) ;
+      --- SetOperationKey(op, key ; res) ;
+      --- return res
+
+      --- For TEE_FreeOperation
+      --- Test Case 1
+      --- keySetOperationForCipherExists ;
+      --- FreeOperation(op ; op) ;
+      --- return res
+
+      --- For TEE_ResetOperation
+      --- Test Case 1
+      keySetOperationForCipherExists ;
+      CipherInit(op, iv ;) ; --- Tested in testCryptoCipher
+      ResetOperation(op ;) ;
+      return res
+    }
+  .
+
+
+
+  eq testCryptoCipher = 
+    main () 
+    {
+      var res ; var op ;
+      var attr ; var key ;
+      var iv ; iv := # noData ;
+      var srcData ; srcData := # randomData ; var destData ;
+
+      --- For TEE_CipherInit
+      --- Test Case 1
+      --- keySetOperationForCipherExists ;
+      --- CipherInit(op, iv ;) ;
+      --- return res
+
+      --- For TEE_CipherUpdate
+      --- Test Case 1
+      --- keySetOperationForCipherExists ;
+      --- CipherInit(op, iv ;) ;
+      --- CipherUpdate(op, srcData ; res, destData) ;
+      --- return destData
+
+      --- For TEE_CipherDoFinal
+      --- Test Case 1
+      keySetOperationForCipherExists ;
+      CipherInit(op, iv ;) ;
+      CipherDoFinal(op, srcData ; res, destData) ;
+      return destData
+    }
+  .
+
+  eq testCryptoMAC = 
+    main () 
+    {
+      var res ; var op ;
+      var attr ; var key ;
+      var iv ; iv := # noData ;
+      var chunk ; chunk := # randomData ;
+      var message ; message := # randomData ;
+      var mac ;
+
+      --- For TEE_MACInit
+      --- Test Case 1
+      --- keySetOperationForMACExists ;
+      --- MACInit(op, iv ;) ;
+      --- return res
+
+      --- For TEE_MACUpdate
+      --- Test Case 1
+      --- keySetOperationForMACExists ;
+      --- MACInit(op, iv ;) ;
+      --- MACUpdate(op, chunk ;) ;
+      --- return res
+
+      --- For TEE_MACComputeFinal
+      --- Test Case 1
+      --- keySetOperationForMACExists ;
+      --- MACInit(op, iv ;) ;
+      --- MACComputeFinal(op, message ; res, mac) ;
+      --- return mac
+
+      --- For TEE_MACCompareFinal
+      --- Test Case 1
+      keySetOperationForMACExists ;
+      MACInit(op, iv ;) ;
+      mac := # macValue(randomData, TEE-ALG-HMAC-SHA256, key(teeAttribute(TEE-ATTR-SECRET-VALUE,randomAttrVal))) ;
+      MACCompareFinal(op, message, mac ; res) ;
+      return res
+    }
+  .
+
+  eq testCryptoMisc = 
+    main () 
+    {
+      var data ;
+      --- For TEE_GenerateRandom
+      --- Test Case 1
+      GenerateRandom(nil ; data) ;
+      return data
+    }
+  .
+endm

--- a/tests/cases/data-stream.maude
+++ b/tests/cases/data-stream.maude
@@ -1,0 +1,49 @@
+mod DATA-STREAM-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  op testDataStream : -> Program [ctor] .
+
+  --- TODO: Fix problem with multiple data flags
+  op openedHandleToPersistentObj : -> Stmt [ctor] .
+  eq openedHandleToPersistentObj = 
+    --- objDataFlag := # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-ACCESS-WRITE, TEE-DATA-FLAG-ACCESS-WRITE-META, TEE-DATA-FLAG-OVERWRITE) ;
+    --- OpenPersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, # objDataFlag  ; res, object) .
+    OpenPersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, # TEE-DATA-FLAG-ACCESS-READ  ; res, object) .
+    --- OpenPersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, # TEE-DATA-FLAG-ACCESS-WRITE  ; res, object) .
+
+  eq testDataStream = 
+    main () 
+    {
+      var res ; 
+      var objDataFlag ; var object ;
+      var data ;
+
+      --- For TEE_ReadObjectData
+      --- Test Case 1
+      --- openedHandleToPersistentObj ;
+      --- ReadObjectData(object, # dataSize(1) ; data, res) ;
+      --- return res
+
+      --- For TEE_WriteObjectData
+      --- Test Case 1 
+      --- openedHandleToPersistentObj ;
+      --- WriteObjectData(object, # noData ; res) ;
+      --- return res
+
+      --- For TEE_TruncateObjectData
+      --- Test Case 1
+      --- openedHandleToPersistentObj ;
+      --- WriteObjectData(object, # noData ; res) ;
+      --- TruncateObjectData(object, # dataSize(0) ; res) ;
+      --- return res
+
+      --- For TEE_SeekObjectData
+      --- Test Case 1 (whence is TEE_DATA_SEEK_SET)
+      openedHandleToPersistentObj ;
+      SeekObjectData(object, # dataSize(7), # TEE-DATA-SEEK-SET ; res) ;
+      return res
+    }
+  .
+endm

--- a/tests/cases/enumerator.maude
+++ b/tests/cases/enumerator.maude
@@ -1,0 +1,42 @@
+mod ENUMERATOR-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  op testEnumerator : -> Program [ctor] .
+
+  op allocatedEnumeratorExists : -> Stmt [ctor] .
+  eq allocatedEnumeratorExists = 
+    AllocatePersistentObjectEnumerator(nil ; res, objEnumerator) .
+
+  eq testEnumerator = 
+    main () 
+    {
+      var res ; var objEnumerator ;
+
+      --- For TEE_AllocatePersistentObjectEnumerator
+      --- Test Case 1
+      --- AllocatePersistentObjectEnumerator(nil ; res, objEnumerator) ;
+      --- return res
+
+      --- For TEE_FreePersistentObjectEnumerator
+      --- Test Case 1
+      --- allocatedEnumeratorExists ;
+      --- FreePersistentObjectEnumerator(objEnumerator ;) ;
+      --- return res
+
+      --- For TEE_StartPersistentObjectEnumerator
+      --- Test Case 1
+      --- allocatedEnumeratorExists ;
+      --- StartPersistentObjectEnumerator(objEnumerator, # TEE-STORAGE-PRIVATE ; res) ;
+      --- return res
+
+      --- For TEE_ResetPersistentObjectEnumerator
+      --- Test Case 1
+      allocatedEnumeratorExists ;
+      StartPersistentObjectEnumerator(objEnumerator, # TEE-STORAGE-PRIVATE ; res) ;
+      ResetPersistentObjectEnumerator(objEnumerator ;) ;
+      return res
+    }
+  .
+endm

--- a/tests/cases/generic.maude
+++ b/tests/cases/generic.maude
@@ -1,0 +1,52 @@
+mod GENERIC-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+  pr TRANSIENT-TEST-CASES .
+  pr DATA-STREAM-TEST-CASES .
+
+  op testGeneric : -> Program [ctor] .
+
+  eq testGeneric = 
+    struct {
+        var objectType ;
+        var objectSize ;
+        var maxObjectSize ; 
+        var objectUsage ;
+        var dataSize ; 
+        var dataPosition ; 
+        var handleFlags 
+    } TeeObjectInfo ;
+
+    main () 
+    {
+      var res ; 
+      var destKey ;
+      var objDataFlag ; var object ;
+
+      --- For TEE_CloseObject
+      --- Test Case 1 (Close transient obj's handle)
+      --- allocatedTransientObjExists ;
+      --- CloseObject(destKey ; destKey) ;
+      --- return res
+
+      --- Test Case 2 (Close persistent obj's handle) (Requires scenario with key)
+      --- openedHandleToPersistentObj ;
+      --- CloseObject(object ; object) ;
+      --- return res
+
+      --- For TEE_GetObjectInfo1
+      --- Test Case 1
+      openedHandleToPersistentObj ;
+      struct TeeObjectInfo objectInfo ;
+      GetObjectInfo1(object  ; res, objectInfo) ;
+      return objectInfo . dataSize
+
+      --- For TEE_GetBufferAttribute
+      --- Test Case 1
+      --- populatedTransientObjExists ;
+      --- GetBufferAttribute(srcKey, # TEE-ATTR-SECRET-VALUE ; res, attr) ;
+      --- return attr
+    }
+  .
+endm

--- a/tests/cases/persistent.maude
+++ b/tests/cases/persistent.maude
@@ -1,0 +1,47 @@
+mod PERSISTENT-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  op testPersistent : -> Program [ctor] .
+
+  op persistentObjExists : -> Stmt [ctor] .
+  eq persistentObjExists =
+    objDataFlag := # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-ACCESS-WRITE, TEE-DATA-FLAG-ACCESS-WRITE-META, TEE-DATA-FLAG-OVERWRITE) ;
+    object  := # handleId(0, testTa)  ; 
+    CreatePersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, objDataFlag, # TEE-HANDLE-NULL, # noData, # dataSize(0), object  ; res , object) .
+
+  eq testPersistent = 
+    main () 
+    {
+      var res ; 
+      var srcKey ; var destKey ;
+      var attr ;
+      var objDataFlag ; var object ;
+
+      --- For TEE_CreatePersistentObject
+      --- Test Case 1 (requires scenario without keys)
+      --- objDataFlag := # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-ACCESS-WRITE, TEE-DATA-FLAG-ACCESS-WRITE-META, TEE-DATA-FLAG-OVERWRITE) ;
+      --- object  := # handleId(0, testTa)  ; 
+      --- CreatePersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, objDataFlag, # TEE-HANDLE-NULL, # noData, # dataSize(0), object  ; res , object) ;
+      --- return res
+
+      --- For TEE_CloseAndDeletePersistentObject1 
+      --- Test Case 1 (requires scenario without keys)
+      --- persistentObjExists ;
+      --- CloseAndDeletePersistentObject1(object ; res) ;
+      --- return res
+
+      --- For TEE_OpenPersistentObject
+      --- Test Case 1
+      --- OpenPersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, # TEE-DATA-FLAG-ACCESS-READ  ; res , object) ;
+      --- return object
+
+      --- For TEE_RenamePersistentObject
+      --- Test Case 1
+      OpenPersistentObject(# TEE-STORAGE-PRIVATE, # testFileId, # TEE-DATA-FLAG-ACCESS-WRITE-META  ; res , object) ;
+      RenamePersistentObject(object, # newTestFileId ; res) ;
+      return res
+    }
+  .
+endm

--- a/tests/cases/transient.maude
+++ b/tests/cases/transient.maude
@@ -1,5 +1,3 @@
-load ../aux
-
 mod TRANSIENT-TEST-CASES is
   pr TEE-BEHAVIOR .
   pr TEE-IMP-BEHAVIOR .

--- a/tests/cases/transient.maude
+++ b/tests/cases/transient.maude
@@ -1,0 +1,75 @@
+load ../aux
+
+mod TRANSIENT-TEST-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  op testTransient : -> Program [ctor] .
+
+  op allocatedTransientObjExists : -> Stmt [ctor] .
+  eq allocatedTransientObjExists = 
+    AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits  ; res, destKey) .
+
+  op populatedTransientObjExists : -> Stmt [ctor] .
+  eq populatedTransientObjExists = 
+    AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits  ; res, srcKey) ;
+    InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+    PopulateTransientObject(srcKey, attr  ; res) .
+
+  eq testTransient = 
+    main () 
+    {
+      var res ; 
+      var srcKey ; var destKey ;
+      var attr ;
+
+      --- For TEE_AllocateTransientObject
+      --- Test Case 1
+      --- AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits  ; res, srcKey) ;
+      --- return res
+
+      --- For TEE_FreeTransientObject
+      --- Test Case 1
+      --- AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits  ; res, srcKey) ;
+      --- FreeTransientObject(srcKey ; srcKey) ;
+      --- return res
+
+      --- For TEE_InitRefAttribute, TEE_InitValueAttribute
+      --- Test Case 1
+      --- InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+      --- return attr
+
+      --- Test Case 2
+      --- InitValueAttribute(# TEE-ATTR-DH-X-BITS, # randomAttrVal  ; attr) ;
+      --- return attr
+
+      --- For TEE_PopulateTransientObject
+      --- Test Case 1
+      --- AllocateTransientObject(# TEE-TYPE-AES, # 256 Bits  ; res, srcKey) ;
+      --- InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+      --- PopulateTransientObject(srcKey, attr  ; res) ;
+      --- return res
+
+      --- For TEE_ResetTransientObject
+      --- Test Case 1
+      --- populatedTransientObjExists ;
+      --- ResetTransientObject(srcKey ; ) ;
+      --- return res
+
+      --- For TEE_CopyObjectAttributes1
+      --- Test Case 1
+      --- populatedTransientObjExists ;
+      --- allocatedTransientObjExists ;
+      --- CopyObjectAttributes1(destKey, srcKey ; res) ;
+      --- return res
+
+      --- For TEE_GenerateKey
+      --- Test Case 1
+      allocatedTransientObjExists ;
+      InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+      GenerateKey(destKey, # 256 Bits, attr ; res) ;
+      return res
+    }
+  .
+endm

--- a/tests/main.maude
+++ b/tests/main.maude
@@ -4,6 +4,7 @@ load ./cases/transient
 load ./cases/persistent
 load ./cases/data-stream
 load ./cases/generic
+load ./cases/cryptographic
 
 mod TEST-DRIVER is
   pr TEE-BEHAVIOR .
@@ -55,6 +56,7 @@ mod TEST-CASES is
   pr PERSISTENT-TEST-CASES .
   pr DATA-STREAM-TEST-CASES .
   pr GENERIC-TEST-CASES .
+  pr CRYPTOGRAPHIC-TEST-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -77,4 +79,8 @@ endm
 --- rew scenarioWithKey(testPersistent) .
 --- rew scenarioWithKey(testDataStream) .
 --- rew scenarioWithoutKey(testGeneric) .
-rew scenarioWithKey(testGeneric) .
+--- rew scenarioWithKey(testGeneric) .
+--- rew scenarioWithKey(testCryptoGeneric) .
+--- rew scenarioWithKey(testCryptoCipher) .
+--- rew scenarioWithKey(testCryptoMAC) .
+rew scenarioWithKey(testCryptoMisc) .

--- a/tests/main.maude
+++ b/tests/main.maude
@@ -2,6 +2,8 @@ load ../src/main
 load ./cases/aux
 load ./cases/transient
 load ./cases/persistent
+load ./cases/data-stream
+load ./cases/generic
 
 mod TEST-DRIVER is
   pr TEE-BEHAVIOR .
@@ -51,6 +53,8 @@ endm
 mod TEST-CASES is
   pr TRANSIENT-TEST-CASES .
   pr PERSISTENT-TEST-CASES .
+  pr DATA-STREAM-TEST-CASES .
+  pr GENERIC-TEST-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -70,4 +74,7 @@ endm
 
 --- rew scenarioWithoutKey(testTransient) .
 --- rew scenarioWithoutKey(testPersistent) .
-rew scenarioWithKey(testPersistent) .
+--- rew scenarioWithKey(testPersistent) .
+--- rew scenarioWithKey(testDataStream) .
+--- rew scenarioWithoutKey(testGeneric) .
+rew scenarioWithKey(testGeneric) .

--- a/tests/main.maude
+++ b/tests/main.maude
@@ -4,6 +4,7 @@ load ./cases/transient
 load ./cases/persistent
 load ./cases/data-stream
 load ./cases/generic
+load ./cases/enumerator
 load ./cases/cryptographic
 
 mod TEST-DRIVER is
@@ -56,6 +57,7 @@ mod TEST-CASES is
   pr PERSISTENT-TEST-CASES .
   pr DATA-STREAM-TEST-CASES .
   pr GENERIC-TEST-CASES .
+  pr ENUMERATOR-TEST-CASES .
   pr CRYPTOGRAPHIC-TEST-CASES .
 endm
 
@@ -80,7 +82,8 @@ endm
 --- rew scenarioWithKey(testDataStream) .
 --- rew scenarioWithoutKey(testGeneric) .
 --- rew scenarioWithKey(testGeneric) .
+rew scenarioWithKey(testEnumerator) .
 --- rew scenarioWithKey(testCryptoGeneric) .
 --- rew scenarioWithKey(testCryptoCipher) .
 --- rew scenarioWithKey(testCryptoMAC) .
-rew scenarioWithKey(testCryptoMisc) .
+--- rew scenarioWithKey(testCryptoMisc) .

--- a/tests/main.maude
+++ b/tests/main.maude
@@ -1,0 +1,65 @@
+load ../src/main
+--- load aux
+load ./cases/transient
+
+mod TEST-DRIVER is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr TEST-AUX .
+
+  var P : Program .
+
+  op osId : -> Oid .
+  op testFileId : -> FileId .
+  ops persistentObjId dataStreamId : -> TaObjectId .
+
+  op initTrustedOS : -> Configuration .
+  eq initTrustedOS
+  = < osId : TeeOSKernel | opened-session : (sessionId(0) |-> testTa) , session-counter : 1 ,
+                           storage : TESTTA |-> testFileId , storage-status : (TESTTA |-> storageNormal) ,
+                           service-request-ta : noAppId , service-request-ta-inst : noInstId ,
+                           service-in : nil , service-out : nil ,
+                           temporary-objects : empty > .
+
+  
+  op testKey : -> Configuration .
+  eq testKey = 
+    < persistentObjId : PersistentObject | handle-set : none , object-type : TEE-TYPE-DATA , max-object-size : 0 Bits  , 
+                                           file-id : testFileId , trust-app-id : TESTTA ,
+                                           attribute-set : empty , object-usage-set : empty , data-stream-id : dataStreamId >
+    < dataStreamId : DataStreamObject | data-size : dataSize(1) , content : newContent(attrContentData(randomAttrVal)) >
+  .
+
+  --- op initRa : Program -> Configuration .
+  --- eq initRa(P) = < ra : RichApp | proc : none , prog : P , running : false , 
+  ---                                 invoke-req-queue : nil , invoke-ret-queue : nil > .
+
+  op initTestTa : Program -> Configuration .
+  eq initTestTa(P) = < testTa : TrustApp | proc : none , prog : P , running : false ,
+                                           app-status : normal , api-call : noCall , api-return : noReturn ,
+                                           current-api : noApi , api-state : noState , current-params : empty , id-counter : 0 ,
+                                           trust-app-id : TESTTA ,
+                                           task : task({sessionId(0) , main , nil} , testRa) , task-counter : 0, state-changed : false > .
+
+endm
+
+mod TEST-CASES is
+  pr TRANSIENT-TEST-CASES .
+endm
+
+mod TEST-SCENARIO is
+  pr TEST-DRIVER .
+  pr TEST-CASES .  
+
+  var P : Program .
+
+  op scenarioWithoutKey : Program -> Configuration .
+  eq scenarioWithoutKey(P)
+    = initTestTa(P) initTrustedOS .
+
+  op scenarioWithKey : Program -> Configuration .
+  eq scenarioWithKey(P)
+    = initTestTa(P) initTrustedOS testKey .
+endm
+
+rew scenarioWithoutKey(testTransient) .

--- a/tests/main.maude
+++ b/tests/main.maude
@@ -1,6 +1,7 @@
 load ../src/main
---- load aux
+load ./cases/aux
 load ./cases/transient
+load ./cases/persistent
 
 mod TEST-DRIVER is
   pr TEE-BEHAVIOR .
@@ -9,9 +10,13 @@ mod TEST-DRIVER is
 
   var P : Program .
 
-  op osId : -> Oid .
-  op testFileId : -> FileId .
-  ops persistentObjId dataStreamId : -> TaObjectId .
+  op initTrustedOSwithNoKey : -> Configuration .
+  eq initTrustedOSwithNoKey
+  = < osId : TeeOSKernel | opened-session : (sessionId(0) |-> testTa) , session-counter : 1 ,
+                           storage : empty , storage-status : (TESTTA |-> storageNormal) ,
+                           service-request-ta : noAppId , service-request-ta-inst : noInstId ,
+                           service-in : nil , service-out : nil ,
+                           temporary-objects : empty > .
 
   op initTrustedOS : -> Configuration .
   eq initTrustedOS
@@ -45,6 +50,7 @@ endm
 
 mod TEST-CASES is
   pr TRANSIENT-TEST-CASES .
+  pr PERSISTENT-TEST-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -55,11 +61,13 @@ mod TEST-SCENARIO is
 
   op scenarioWithoutKey : Program -> Configuration .
   eq scenarioWithoutKey(P)
-    = initTestTa(P) initTrustedOS .
+    = initTestTa(P) initTrustedOSwithNoKey .
 
   op scenarioWithKey : Program -> Configuration .
   eq scenarioWithKey(P)
     = initTestTa(P) initTrustedOS testKey .
 endm
 
-rew scenarioWithoutKey(testTransient) .
+--- rew scenarioWithoutKey(testTransient) .
+--- rew scenarioWithoutKey(testPersistent) .
+rew scenarioWithKey(testPersistent) .


### PR DESCRIPTION
Added tests for current API specifications.

Major additions:
- Test framework to run tests
- Test cases defining scenarios in which individual APIs could and should function

Note:
The current tests are compatible with commit 51c30ef (the version used in tee-formal-analysis).
While they do not fully align with the current language syntax/semantics, the tests provide valuable insight into how the APIs should work. Updating should be straightforward once the latest language syntax and semantics are finalized.

For example, using these tests, a bug was discovered in the specification:
- For the specification of `TEE_FreePersistentObjectEnumerator` function
  - In G.P. spec.: the function returns void
  - In our model: the function returns TEE_Result

(will open an issue containing all identified bugs as soon as possible.)